### PR TITLE
convert A and W to complex numbers in czt

### DIFF
--- a/czt.py
+++ b/czt.py
@@ -45,6 +45,8 @@ def czt(x, M=None, W=None, A=1.0, simple=False, t_method='ce', f_method='std'):
         M = N
     if W is None:
         W = np.exp(-2j * np.pi / M)
+    A = complex(A)
+    W = complex(W)
         
     if simple:
         k = np.arange(M)


### PR DESCRIPTION
avoid int**(-np.ndarray(dtype=int)) Error if user provides them as int in the argument list.
Possible fix for #4 