### PR TITLE
Remove circular dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ from os import path
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
-import czt
-
 root = path.abspath(path.dirname(__file__))
 
 def read(*filenames, **kwargs):


### PR DESCRIPTION
Removes an import that causes a circular dependency during install. By calling `import czt` inside `setup.py` it requires the install requirements to already be installed. I see you tried to get the version string into `setup.py` this way. Instead, you could use [`pbr`](https://docs.openstack.org/pbr/latest/).

When installing, I get the following error:
```bash
Collecting czt
  Using cached czt-0.0.6.tar.gz (6.6 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_975476128302463395b47134e2bd67fa/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_975476128302463395b47134e2bd67fa/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-shw4od_q
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_975476128302463395b47134e2bd67fa/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_975476128302463395b47134e2bd67fa/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_975476128302463395b47134e2bd67fa/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/34/d5/6891625b190e7f280cba86c937520489d6122744fdfc8698d6688c60fe3f/czt-0.0.6.tar.gz#sha256=9c6992d9a5b140c190287c1e3dea7258906c9419c9f61b41cc61f5bb71cac9da (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.5.tar.gz (6.9 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_3fea88674a1449b6b4d70d3aec2c4d3e/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_3fea88674a1449b6b4d70d3aec2c4d3e/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-j9ulz_5c
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_3fea88674a1449b6b4d70d3aec2c4d3e/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_3fea88674a1449b6b4d70d3aec2c4d3e/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_3fea88674a1449b6b4d70d3aec2c4d3e/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/b7/6e/2698d377312636cb2df53316d8ca8002c3c8c427e1216744e074f263d583/czt-0.0.5.tar.gz#sha256=492503fc38e32db13c636dbe159686a9d00be9479e0079bd412e46663ddd4c5d (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.4.tar.gz (6.8 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_6b74448de9ee4ddeaa387c420b1ea0f0/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_6b74448de9ee4ddeaa387c420b1ea0f0/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-23kd96lm
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_6b74448de9ee4ddeaa387c420b1ea0f0/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_6b74448de9ee4ddeaa387c420b1ea0f0/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_6b74448de9ee4ddeaa387c420b1ea0f0/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/7a/75/31889fb93e61f3cc68effa8c995b911dd8c100c1367c5c2422b373b19078/czt-0.0.4.tar.gz#sha256=82bacefe9bbddedac29a294941e4d7c57b088b2e3c9c3a7f767a0343ee151531 (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.3.tar.gz (7.0 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_2c47c9f9f2a74ceaab534066437aab29/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_2c47c9f9f2a74ceaab534066437aab29/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-q9vpxz72
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_2c47c9f9f2a74ceaab534066437aab29/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_2c47c9f9f2a74ceaab534066437aab29/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_2c47c9f9f2a74ceaab534066437aab29/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/7c/8b/1df27febd1951a229553c4a3e946e966ad11e8ccade9a13072828bafb695/czt-0.0.3.tar.gz#sha256=ed2456b1124b62fb63cd2f71bfea1764a452aebbf99149d87b5b218b75e8c5aa (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.2.tar.gz (6.3 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_91e73741dadf4021ab6f4eca5511c6d2/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_91e73741dadf4021ab6f4eca5511c6d2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-iz_ibld_
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_91e73741dadf4021ab6f4eca5511c6d2/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_91e73741dadf4021ab6f4eca5511c6d2/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-f8gcwx_q/czt_91e73741dadf4021ab6f4eca5511c6d2/czt.py", line 11, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/6b/08/144ef96d45dec2ed2d21be8f92519d90e4bf9250b73e92df52b1ccbec425/czt-0.0.2.tar.gz#sha256=4f4472218151920211400c5d085353219c651c6b6342428d1ec77e8fea3d6471 (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.1-py3-none-any.whl (3.1 kB)
ERROR: Could not find a version that satisfies the requirement citi (from wvi)
ERROR: No matching distribution found for citi
(wvi) besler@Bryces-MacBook-Pro pyreco % pip install czt
Collecting czt
  Using cached czt-0.0.6.tar.gz (6.6 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_44e0da2db95548aea11e603cac603bd4/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_44e0da2db95548aea11e603cac603bd4/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-qstt763c
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_44e0da2db95548aea11e603cac603bd4/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_44e0da2db95548aea11e603cac603bd4/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_44e0da2db95548aea11e603cac603bd4/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/34/d5/6891625b190e7f280cba86c937520489d6122744fdfc8698d6688c60fe3f/czt-0.0.6.tar.gz#sha256=9c6992d9a5b140c190287c1e3dea7258906c9419c9f61b41cc61f5bb71cac9da (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.5.tar.gz (6.9 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_5948b4e88ef044f091c58aa1e71a5380/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_5948b4e88ef044f091c58aa1e71a5380/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-no3oj7zq
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_5948b4e88ef044f091c58aa1e71a5380/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_5948b4e88ef044f091c58aa1e71a5380/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_5948b4e88ef044f091c58aa1e71a5380/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/b7/6e/2698d377312636cb2df53316d8ca8002c3c8c427e1216744e074f263d583/czt-0.0.5.tar.gz#sha256=492503fc38e32db13c636dbe159686a9d00be9479e0079bd412e46663ddd4c5d (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.4.tar.gz (6.8 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_9cd158544c354e99bc96b59ee7f072c6/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_9cd158544c354e99bc96b59ee7f072c6/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-lbmfh9zw
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_9cd158544c354e99bc96b59ee7f072c6/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_9cd158544c354e99bc96b59ee7f072c6/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_9cd158544c354e99bc96b59ee7f072c6/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/7a/75/31889fb93e61f3cc68effa8c995b911dd8c100c1367c5c2422b373b19078/czt-0.0.4.tar.gz#sha256=82bacefe9bbddedac29a294941e4d7c57b088b2e3c9c3a7f767a0343ee151531 (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.3.tar.gz (7.0 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_f6a715fc114d48ee864f67e8d8f20ff8/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_f6a715fc114d48ee864f67e8d8f20ff8/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-46g3hcmt
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_f6a715fc114d48ee864f67e8d8f20ff8/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_f6a715fc114d48ee864f67e8d8f20ff8/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_f6a715fc114d48ee864f67e8d8f20ff8/czt.py", line 16, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/7c/8b/1df27febd1951a229553c4a3e946e966ad11e8ccade9a13072828bafb695/czt-0.0.3.tar.gz#sha256=ed2456b1124b62fb63cd2f71bfea1764a452aebbf99149d87b5b218b75e8c5aa (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  Using cached czt-0.0.2.tar.gz (6.3 kB)
    ERROR: Command errored out with exit status 1:
     command: /opt/anaconda3/envs/wvi/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_15f27d2d82f34ec7b842d203c34f0db0/setup.py'"'"'; __file__='"'"'/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_15f27d2d82f34ec7b842d203c34f0db0/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-pip-egg-info-o6qb8qxa
         cwd: /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_15f27d2d82f34ec7b842d203c34f0db0/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_15f27d2d82f34ec7b842d203c34f0db0/setup.py", line 11, in <module>
        import czt
      File "/private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-vgh7yirg/czt_15f27d2d82f34ec7b842d203c34f0db0/czt.py", line 11, in <module>
        import numpy as np
    ModuleNotFoundError: No module named 'numpy'
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/6b/08/144ef96d45dec2ed2d21be8f92519d90e4bf9250b73e92df52b1ccbec425/czt-0.0.2.tar.gz#sha256=4f4472218151920211400c5d085353219c651c6b6342428d1ec77e8fea3d6471 (from https://pypi.org/simple/czt/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

I get reasonableness from this:
```bash
Collecting czt@ git+git://github.com/Besler/CZT@main
  Cloning git://github.com/Besler/CZT (to revision main) to /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-cuz6flrb/czt_6cbb8fdd78e84eeaa88492c13b9c0d47
  Running command git clone -q git://github.com/Besler/CZT /private/var/folders/t1/cmbt37z92lv8nm0xg0g75v480000gn/T/pip-install-cuz6flrb/czt_6cbb8fdd78e84eeaa88492c13b9c0d47
  ```
