### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    [cron: "0 12 * * 0"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: [3.8]
+    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}-${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-${{ matrix.python-version }}-
+      - run: pip install -r requirements-dev.txt
+      - run: pip install -e .
+      - name: Test
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Chirp Z-Transform (CZT)
 =======================
 
 [![PyPI version](https://badge.fury.io/py/czt.svg)](https://badge.fury.io/py/czt)
+[![ci](https://github.com/garrettj403/CZT/actions/workflows/ci.yml/badge.svg)](https://github.com/garrettj403/CZT/actions/workflows/ci.yml)
 
 From [Wikipedia](https://en.wikipedia.org/wiki/Chirp_Z-transform):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# From requirements.txt
+numpy
+scipy>=1.6.0
+
+# Dev additions
+pytest
+matplotlib


### PR DESCRIPTION
This PR adds continuous integration to the package. This should make it easier to maintain the package. I imagine you will want to set everything up *just so*, so I would recommend going through the commits and making it what you want.

Description:
- Adds a `requirements-dev.txt`. These have the same dependencies as `requirements.txt`, but adds some extra ones for developers such as `matplotlib` and `pytest`. These are needed for testing, but not importing.

**Description of CIs**
Since this is an open source project, you don't have to pay for GitHub action minutes. I chose GitHub Actions over, say, CircleCI because it is so easy to integrate. Each workflow is described below. For all the CIs:
- Runs on `ubuntu-latest`, `windows-latest`, `macOS-latest`
- Runs only Python 3.8 right now. It's obvious how to modify this behaviour in `ci.yml` so you can add 3.9, 3.10, etc.

`.github/workflows/ci.yml`
- Runs `pytest -v`
